### PR TITLE
fix: each render creates a new instance

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -5,7 +5,7 @@ const generateId = prefix => `${prefix}${('' + Math.random()).split('.')[1]}`
 
 const wrap = rvComp => ({ prefix, ...props }) => {
   const ref = useRef()
-  const [id] = useState(generateId(prefix || 'roughviz-'))
+  const [ id ] = useState(generateId(prefix || 'roughviz-'))
   useEffect(() => {
     if (ref.current) {
       // since this effect runs only on prop changes,
@@ -17,10 +17,10 @@ const wrap = rvComp => ({ prefix, ...props }) => {
         ...props
       })
     }
-  }, [id, props])
+  }, [ id, props ])
 
   return <div id={id} ref={ref} />
-};
+}
 
 export const Bar = wrap(rv.Bar)
 export const BarH = wrap(rv.BarH)

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,27 +1,31 @@
-import React, { useRef, useState, useEffect } from 'react'
-import * as rv from 'rough-viz/dist/roughviz.min'
+import React, { useRef, useState, useEffect } from 'react';
+import * as rv from 'rough-viz/dist/roughviz.min';
 
-const generateId = prefix => `${prefix}${('' + Math.random()).split('.')[1]}`
+const generateId = prefix => `${prefix}${('' + Math.random()).split('.')[1]}`;
 
 const wrap = rvComp => ({ prefix, ...props }) => {
-  const ref = useRef()
-  const [ id ] = useState(generateId(prefix || 'roughviz-'))
+  const ref = useRef();
+  const [id] = useState(generateId(prefix || 'roughviz-'));
   useEffect(() => {
     if (ref.current) {
+      // since this effect runs only on prop changes,
+      // it's safe to assume we want to redraw
+      ref.current.childNodes.forEach(node => node.remove());
+
       new rvComp({
         element: '#' + id,
         ...props
-      })
+      });
     }
-  }, [ ref, id, props ])
+  }, [id, props]);
 
-  return <div id={id} ref={ref} />
-}
+  return <div id={id} ref={ref} />;
+};
 
-export const Bar = wrap(rv.Bar)
-export const BarH = wrap(rv.BarH)
-export const Donut = wrap(rv.Donut)
-export const Pie = wrap(rv.Pie)
-export const Scatter = wrap(rv.Scatter)
-export const Line = wrap(rv.Line)
-export const StackedBar = wrap(rv.StackedBar)
+export const Bar = wrap(rv.Bar);
+export const BarH = wrap(rv.BarH);
+export const Donut = wrap(rv.Donut);
+export const Pie = wrap(rv.Pie);
+export const Scatter = wrap(rv.Scatter);
+export const Line = wrap(rv.Line);
+export const StackedBar = wrap(rv.StackedBar);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,31 +1,31 @@
-import React, { useRef, useState, useEffect } from 'react';
-import * as rv from 'rough-viz/dist/roughviz.min';
+import React, { useRef, useState, useEffect } from 'react'
+import * as rv from 'rough-viz/dist/roughviz.min'
 
-const generateId = prefix => `${prefix}${('' + Math.random()).split('.')[1]}`;
+const generateId = prefix => `${prefix}${('' + Math.random()).split('.')[1]}`
 
 const wrap = rvComp => ({ prefix, ...props }) => {
-  const ref = useRef();
-  const [id] = useState(generateId(prefix || 'roughviz-'));
+  const ref = useRef()
+  const [id] = useState(generateId(prefix || 'roughviz-'))
   useEffect(() => {
     if (ref.current) {
       // since this effect runs only on prop changes,
       // it's safe to assume we want to redraw
-      ref.current.childNodes.forEach(node => node.remove());
+      ref.current.childNodes.forEach(node => node.remove())
 
       new rvComp({
         element: '#' + id,
         ...props
-      });
+      })
     }
-  }, [id, props]);
+  }, [id, props])
 
-  return <div id={id} ref={ref} />;
+  return <div id={id} ref={ref} />
 };
 
-export const Bar = wrap(rv.Bar);
-export const BarH = wrap(rv.BarH);
-export const Donut = wrap(rv.Donut);
-export const Pie = wrap(rv.Pie);
-export const Scatter = wrap(rv.Scatter);
-export const Line = wrap(rv.Line);
-export const StackedBar = wrap(rv.StackedBar);
+export const Bar = wrap(rv.Bar)
+export const BarH = wrap(rv.BarH)
+export const Donut = wrap(rv.Donut)
+export const Pie = wrap(rv.Pie)
+export const Scatter = wrap(rv.Scatter)
+export const Line = wrap(rv.Line)
+export const StackedBar = wrap(rv.StackedBar)


### PR DESCRIPTION
@Chris927 
fixes: https://github.com/Chris927/react-roughviz/issues/7

I ran into the issue above as well, and my proposed fix, until (if) the base library provides a redraw method which would let us be smarter, is to just clear out the child nodes on the container `div` for now and then recreate the graph. 

This fixed in local testing.

Also, my vscode went HAM on linting and decided to "clean" stuff up. Happy to remove those changes if you prefer without the semi-colons and spaces.